### PR TITLE
fix: Refresh token status code should be 401

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Injectable,
   BadRequestException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { AuthDto } from './dto';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -141,7 +142,7 @@ export class AuthService {
     id: string;
     refreshToken: string;
   }) {
-    if (!refreshToken) throw new ForbiddenException('Invalid token');
+    if (!refreshToken) throw new UnauthorizedException('Invalid refresh token');
 
     const user = await this.prisma.user.findUnique({
       where: {
@@ -151,13 +152,14 @@ export class AuthService {
         },
       },
     });
-    if (!user) throw new ForbiddenException('Invalid credentials');
+    if (!user) throw new UnauthorizedException('Invalid refresh token');
 
     const isRefreshTokenMatches = await bcrypt.compare(
       refreshToken,
       user.hashedRefreshToken || '',
     );
-    if (!isRefreshTokenMatches) throw new ForbiddenException('Invalid token');
+    if (!isRefreshTokenMatches)
+      throw new UnauthorizedException('Invalid refresh token');
 
     const decodedToken = this.jwtService.decode(refreshToken) as JwtPayload;
 

--- a/apps/web/app/lib/axios.ts
+++ b/apps/web/app/lib/axios.ts
@@ -28,10 +28,11 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const status = response.status;
+    const status = response?.status;
+    const message = response?.data?.message;
 
-    // API returns 403 when could not refresh tokens.
-    if (status === 403) {
+    // API returns 401 and message is "Invalid refresh token". redirect to login
+    if (status === 401 && message === "Invalid refresh token") {
       if (window.location.pathname !== "/login") {
         window.location.replace("/login");
       }


### PR DESCRIPTION
API: accessToken invalid ise 401, refreshToken invalid ise 403 dönüyor.
API: kullacının rolünün yetkisiz olduğu durumlarda 403 dönüyor.
Client: API 403 döndüğünde kullanıcıyı direkt login sayfasına yönlendiriyor.

Authenticatio ve Unauthorized'ı ayırmak için artık refreshToken invalid ise 401 dönüyoruz ve message koduna 'Invalid refresh token' yazıyoruz. Client buna göre işlem yapıyor.

> Internette çoğu insan 401 dönmeli yazmış